### PR TITLE
Game project (csproj) fix for references paths and content copying upon build system. According to native libs the target platform should be x64.

### DIFF
--- a/SharpPong.sln
+++ b/SharpPong.sln
@@ -13,10 +13,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{52A06076-E6C1-46C8-8818-11B9E2A79A65}.Release|Any CPU.ActiveCfg = Release|x64
 		{D4FA1C1E-0C43-425B-AE62-93279DD6B90D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D4FA1C1E-0C43-425B-AE62-93279DD6B90D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4FA1C1E-0C43-425B-AE62-93279DD6B90D}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/SharpPong/SharpPong.csproj
+++ b/SharpPong/SharpPong.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{52A06076-E6C1-46C8-8818-11B9E2A79A65}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -28,7 +28,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -38,8 +38,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -49,16 +49,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="sfmlnet-audio-2">
-      <HintPath>..\..\Biblioteki\SFML.Net-2.2\lib\sfmlnet-audio-2.dll</HintPath>
+      <HintPath>lib\sfmlnet-audio-2.dll</HintPath>
     </Reference>
     <Reference Include="sfmlnet-graphics-2">
-      <HintPath>..\..\Biblioteki\SFML.Net-2.2\lib\sfmlnet-graphics-2.dll</HintPath>
+      <HintPath>lib\sfmlnet-graphics-2.dll</HintPath>
     </Reference>
     <Reference Include="sfmlnet-system-2">
-      <HintPath>..\..\Biblioteki\SFML.Net-2.2\lib\sfmlnet-system-2.dll</HintPath>
+      <HintPath>lib\sfmlnet-system-2.dll</HintPath>
     </Reference>
     <Reference Include="sfmlnet-window-2">
-      <HintPath>..\..\Biblioteki\SFML.Net-2.2\lib\sfmlnet-window-2.dll</HintPath>
+      <HintPath>lib\sfmlnet-window-2.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -70,11 +70,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Arkanoid.cs" />
     <Compile Include="Ball.cs" />
     <Compile Include="Game.cs" />
+    <Compile Include="Multiplayer.cs" />
     <Compile Include="Player.cs" />
+    <Compile Include="Pong.cs" />
+    <Compile Include="PongHotSeat.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResourceManager.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Tiles.cs" />
   </ItemGroup>
@@ -94,30 +99,44 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="csfml-audio-2.dll">
+	<Content Include="resources\*">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+	<Content Include="resources\textures\*">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+    <ContentWithTargetPath Include="lib\csfml-audio-2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="csfml-graphics-2.dll">
+	  <TargetPath>csfml-audio-2.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\csfml-graphics-2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="csfml-system-2.dll">
+	  <TargetPath>csfml-graphics-2.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\csfml-system-2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="csfml-window-2.dll">
+	  <TargetPath>csfml-system-2.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\csfml-window-2.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="libsndfile-1.dll">
+	  <TargetPath>csfml-window-2.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\libsndfile-1.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="openal32.dll">
+	  <TargetPath>libsndfile-1.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\openal32.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="OpenTK.Compatibility.dll">
+	  <TargetPath>openal32.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\OpenTK.Compatibility.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="OpenTK.dll">
+	  <TargetPath>OpenTK.Compatibility.dll</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\OpenTK.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+	  <TargetPath>OpenTK.dll</TargetPath>
+    </ContentWithTargetPath>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
@Pina92 this might help to run solution across platforms and make easier on deploying app to potential testers :)